### PR TITLE
Added "email", "openid" to scopes

### DIFF
--- a/js/jquery.auth.js
+++ b/js/jquery.auth.js
@@ -25,7 +25,7 @@
     });
 
     var loginRequest = {
-        scopes: ["https://isvcanvas.onmicrosoft.com/isvcanvasapi/Read", "https://isvcanvas.onmicrosoft.com/isvcanvasapi/Save"], // optional Array<string>
+         scopes: ["email", "openid","https://isvcanvas.onmicrosoft.com/isvcanvasapi/Read",  "https://isvcanvas.onmicrosoft.com/isvcanvasapi/Save"], // optional Array<string>
     };
 
     function Plugin(element, options) {


### PR DESCRIPTION
We need to add
"email", "openid" scopes
in order to get consistency in the token that is generated.

For example now for email you are getting the username which might be the email but it is not mandatory